### PR TITLE
Configure Supabase env vars for Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Environment variables
+
+Create a `.env` file in the project root with the following entries:
+
+```bash
+SUPABASE_URL=<your supabase url>
+SUPABASE_PUBLISHABLE_KEY=<your supabase key>
+```
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/7af690cb-50c4-43fd-8029-751f4eb91a37) and click on Share -> Publish.

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://hginfezoozyzhkqejrhd.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhnaW5mZXpvb3p5emhrcWVqcmhkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA0NDIzMjksImV4cCI6MjA2NjAxODMyOX0.GvQLb4a2TaWnhtSBqgAnOxGO3E4lcvjinoYEexHZLdI";
+const SUPABASE_URL = import.meta.env.SUPABASE_URL;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.SUPABASE_PUBLISHABLE_KEY;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly SUPABASE_URL: string
+  readonly SUPABASE_PUBLISHABLE_KEY: string
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(({ mode }) => ({
     host: "::",
     port: 8080,
   },
+  envPrefix: ["VITE_", "SUPABASE_"],
   plugins: [
     react(),
     mode === 'development' &&


### PR DESCRIPTION
## Summary
- read Supabase credentials from `import.meta.env`
- expose `SUPABASE_` variables to Vite via `envPrefix`
- type env variables in `vite-env.d.ts`
- document `.env` variables in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688a4844bcc0832f988ca0dccd9c76f9